### PR TITLE
fix month & year styling

### DIFF
--- a/src/components/DateTimePicker/sass/DateTimePicker.scss
+++ b/src/components/DateTimePicker/sass/DateTimePicker.scss
@@ -122,6 +122,52 @@
     }
   }
 
+  .rdtMonths {
+    & .rdtMonth {
+      text-align: center; 
+      vertical-align: middle;
+
+      &.rdtActive {
+        background-color: theme-color('primary', 'base') !important;
+        color: white;
+      }
+    }
+
+    & tbody {
+      & td:first-child {
+        padding-left: 0px;
+      }
+
+      & td:last-child {
+        padding-right: 0px;
+      }
+    }
+  }
+
+  .rdtYears {
+    & .rdtYear {
+      text-align: center; 
+      vertical-align: middle;
+
+      &.rdtActive {
+        background-color: theme-color('primary', 'base') !important;
+        color: white;
+      }
+    }
+
+    & tbody {
+      & tr:last-child {
+        & td {
+          padding: 0;
+        }
+      }
+
+      & td:first-child, & td:last-child {
+        padding: 0;
+      }
+    }
+  }
+
   .rdtTimeToggle {
     padding: 15px 0;
 


### PR DESCRIPTION
Check how it looks here https://tyktechnologies.github.io/tyk-ui-styleguide/#datetimepicker

How it looks after those changes:
<img width="240" alt="Screenshot 2019-08-30 at 13 02 40" src="https://user-images.githubusercontent.com/12560939/64019256-8e69b980-cb26-11e9-9e05-a86e4aa16835.png">
<img width="239" alt="Screenshot 2019-08-30 at 13 02 48" src="https://user-images.githubusercontent.com/12560939/64019257-8f025000-cb26-11e9-9f26-cbeb4ce22b38.png">
