### PR TITLE
adds a small sanity check to the shouldLoad function (InfiniteScroller)

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -30,7 +30,7 @@ jobs:
           ${{ runner.os }}-test-${{ matrix.node-version }}
           ${{ runner.os }}-
     - name: install
-      run: npm config set //registry.npmjs.org/:_authToken "${{ secrets. NPM_TOKEN }}" && npm install
+      run: npm config set //registry.npmjs.org/:_authToken "${{ secrets. NPM_TOKEN }}" && npm install --force
     - name: cypress install
       run: npx cypress install
     - name: test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "2.2.27",
+  "version": "2.2.28",
   "description": "Tyk UI - ui reusable components",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/InfiniteScroller/index.js
+++ b/src/components/InfiniteScroller/index.js
@@ -28,6 +28,7 @@ function InfiniteScroller(props) {
   }, [initialLoad]);
 
   const shouldLoad = useCallback(() => {
+    if (!containerRef.current) return false;
     const { clientHeight, scrollTop } = containerRef.current;
 
     return (
@@ -66,7 +67,6 @@ function InfiniteScroller(props) {
       }
     };
   }, [containerRef, scrollHandler]);
-
 
   // if content resets (page number resets) scroll to top
   useEffect(() => {


### PR DESCRIPTION
When running tests I encountered a bug where the `shouldLoad` function executes even though `containerRef.current` is `null` which raises an error on destructuring. I assume it has something to do with using a scroll handler defined using `useCallback` and `debounce` in the component.
I added a sanity check for `containerRef.current` as a fix.