### PR TITLE
align input checkbox to the top instead of the center relative to the label

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "2.2.28",
+  "version": "2.2.29",
   "description": "Tyk UI - ui reusable components",
   "main": "lib/index.js",
   "scripts": {

--- a/src/common/sass/components.scss
+++ b/src/common/sass/components.scss
@@ -27,7 +27,6 @@
 // -- Form Components
 @import '../../form/components/Combobox2/sass/Combobox';
 @import '../../form/components/Checkbox/sass/Checkbox';
-@import '../../form/components/Checkbox/sass/Checkbox';
 @import '../../form/components/DatePicker/sass/DatePicker';
 @import '../../form/components/Dropdown/sass/Dropdown';
 @import '../../form/components/EditableList/sass/EditableList';

--- a/src/form/components/Checkbox/sass/Checkbox.scss
+++ b/src/form/components/Checkbox/sass/Checkbox.scss
@@ -6,6 +6,7 @@
   label {
     $label-indent: 20px;
     display: flex;
+    align-items: flex-start;
     padding-left: $label-indent;
 
     input {


### PR DESCRIPTION
Redoing what I tried to fix in https://github.com/TykTechnologies/tyk-ui/pull/242.
I swear it was working, not sure what happened.