### PR TITLE
version upgrade - just to publish a new version that includes the lib build

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "2.2.40",
+  "version": "2.2.41",
   "description": "Tyk UI - ui reusable components",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
bump the lib version for the following reason
I accidentally published the wrong thing under the 2.2.40 version. It didn't include the build of the lib from that commit.
So I unpublished the 2.2.40 version and need to publish a new version with the correct build.