### PR TITLE
bump version to be able to publish the latest changes to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tyk-technologies/tyk-ui",
-      "version": "3.0.5",
+      "version": "3.0.6",
       "license": "ISC",
       "dependencies": {
         "brace": "0.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "description": "Tyk UI - ui reusable components",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
last version on npm is 3.0.5 and the version in package.json before that latest changes was 3.0.4
bumping version to 3.0.6 to be able to publish a new version to npm and to be in sync again with the package.json version