### PR TITLE
Switch button order on Confirm component for consistency with Tyk …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tyk-ui-styleguide
 coverage
 .nyc_output
 *DS_Store
+.idea/

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="Eslint" enabled="true" level="WARNING" enabled_by_default="true" />
+  </profile>
+</component>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tyk-ui.iml" filepath="$PROJECT_DIR$/.idea/tyk-ui.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tyk-ui.iml
+++ b/.idea/tyk-ui.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -61,16 +61,16 @@ function Confirm(props) {
         </Modal.Body>
         <Modal.Footer>
           <Button
-            onClick={confirm}
-            theme="success"
-          >
-            {confirmBtnText}
-          </Button>
-          <Button
             onClick={cancel}
             theme="default"
           >
             {cancelBtnText}
+          </Button>
+          <Button
+            onClick={confirm}
+            theme="success"
+          >
+            {confirmBtnText}
           </Button>
         </Modal.Footer>
       </Modal>


### PR DESCRIPTION
switching the order of these buttons so that the confirm is on the right inline with the general style of the rest of the product.