### PR TITLE
switch button order on Confirm component

### DIFF
--- a/src/components/Confirm/index.js
+++ b/src/components/Confirm/index.js
@@ -61,16 +61,16 @@ function Confirm(props) {
         </Modal.Body>
         <Modal.Footer>
           <Button
+              onClick={cancel}
+              theme="default"
+          >
+            {cancelBtnText}
+          </Button>
+          <Button
             onClick={confirm}
             theme="success"
           >
             {confirmBtnText}
-          </Button>
-          <Button
-            onClick={cancel}
-            theme="default"
-          >
-            {cancelBtnText}
           </Button>
         </Modal.Footer>
       </Modal>


### PR DESCRIPTION
switching the order of these buttons so that the confirm is on the right inline with the general style of the rest of the product.