### PR TITLE
TUI-97: workaround for making CSSTransition used by the Collapsible and Modal components work with react 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tyk-technologies/tyk-ui",
-      "version": "4.4.17",
+      "version": "4.4.20",
       "license": "ISC",
       "dependencies": {
         "ace-builds": "1.36.4",
@@ -14026,6 +14026,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -14430,6 +14431,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -15406,6 +15408,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tyk-technologies/tyk-ui",
-  "version": "4.4.19",
+  "version": "4.4.20",
   "description": "Tyk UI - ui reusable components",
   "main": "src/index.js",
   "scripts": {

--- a/src/components/Collapsible/index.js
+++ b/src/components/Collapsible/index.js
@@ -62,6 +62,7 @@ function Collapsible({
       in={!collapsed}
       timeout={0}
       classNames="collapse"
+      nodeRef={collapseWrapper}
     >
       <div
         className="collapse-wrapper"

--- a/src/components/Modal/index.js
+++ b/src/components/Modal/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import { CSSTransition } from 'react-transition-group';
@@ -25,6 +25,8 @@ function Modal({
   showBackdrop = true,
   ...restProps
 }) {
+  const modalRef = useRef();
+  const backdropRef = useRef();
   const theme = ['success', 'warning', 'danger', 'info'].includes(themeProp) ? themeProp : 'default';
   const modalClasses = [
     'tyk-modal',
@@ -52,8 +54,9 @@ function Modal({
             in={opened}
             timeout={100}
             classNames="appear"
+            nodeRef={modalRef}
           >
-            <div className={modalClasses} {...restProps}>
+            <div className={modalClasses} {...restProps} ref={modalRef}>
               <div className={`tyk-modal__dialog tyk-modal--${size}`}>
                 <div className="tyk-modal__content">
                   {themeIcon && (
@@ -75,8 +78,10 @@ function Modal({
           in={opened}
           timeout={100}
           classNames="fade"
+          nodeRef={backdropRef}
         >
           <button
+            ref={backdropRef}
             className={backdropClasses}
             onClick={() => !disableCloseCommands && onClose?.()}
             onKeyDown={() => {}}


### PR DESCRIPTION
https://tyktech.atlassian.net/browse/TUI-97

In react 19 the `findDOMNode` method was removed which is used by the old `react-transition-group` module. This PR introduces a workaround to make it work with react 19 by circumventing the calls to `findDOMNode`. 
The workaround is inspired from the comments for this github issue https://github.com/reactjs/react-transition-group/issues/918.