### PR TITLE
[TT-17030] Migrate from TYK_UI_TOKEN PAT to GitHub App token

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -18,11 +18,19 @@ jobs:
         node-version: [16.x]
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744  # v3
         with:
           fetch-depth: 0
-          token: ${{ secrets.TYK_UI_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Use node ${{ matrix.node-version }}
         uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610  # v3
         with:


### PR DESCRIPTION
## Summary
- Replace `TYK_UI_TOKEN` (repo-level PAT) in `build-and-publish.yml` (checkout token) with a token generated by `actions/create-github-app-token`

### Files changed
- `.github/workflows/build-and-publish.yml` — checkout step's token parameter

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org-level secrets are available to this repo
- [ ] Push to master and confirm the build-and-publish workflow can checkout, build, commit, and push successfully with the app token

🤖 Generated with [Claude Code](https://claude.com/claude-code)